### PR TITLE
a bug in maximum response

### DIFF
--- a/build_histogram_models.m
+++ b/build_histogram_models.m
@@ -20,7 +20,7 @@ for i=1:no_classes
         image_name = training_images{j,i};
         
         filter_response = im2filter_response( image_name,patch_width,patch_height,filter_bank,training_options);
-        histogram= filter_respone2histogram( filter_response,training_class_centroid,NUM_BINS);
+        histogram= filter_response2histogram( filter_response,training_class_centroid,NUM_BINS);
         
         index = j+ (i-1)*training_per_class;
         training_histogram(index,:) = histogram;

--- a/classify_images.m
+++ b/classify_images.m
@@ -28,7 +28,7 @@ for i=1:no_classes
     for j=1:test_per_class 
         image_name = test_images{j,i};
         filter_response = im2filter_response( image_name,patch_width,patch_height,filter_bank,classification_options);
-        histogram= filter_respone2histogram( filter_response,training_class_centroid,NUM_BINS);
+        histogram= filter_response2histogram( filter_response,training_class_centroid,NUM_BINS);
     
         test_histogram(test_index,:) = histogram;
         test_classes(test_index,:) = i;

--- a/filter_response2histogram.m
+++ b/filter_response2histogram.m
@@ -1,4 +1,4 @@
-function [ histogram   ] = filter_respone2histogram( filter_response,training_class_centroid,NUM_BINS)
+function [ histogram   ] = filter_response2histogram( filter_response,training_class_centroid,NUM_BINS)
     image_size = size(filter_response,1);
     
     texton_map = zeros(image_size ,1);

--- a/im2filter_response.m
+++ b/im2filter_response.m
@@ -10,12 +10,15 @@ for k=1:size(filter,3)
 end;
 if strfind(options, 'MR8')
     filter_response_MR8 = zeros(size(training_im,1)*size(training_im,2),8);
-    filter_response_MR8(:,1) = max(filter_response(:,1:6),[],2);
-    filter_response_MR8(:,2) = max(filter_response(:,7:12),[],2);
-    filter_response_MR8(:,3) = max(filter_response(:,13:18),[],2);
-    filter_response_MR8(:,4) = max(filter_response(:,19:24),[],2);
-    filter_response_MR8(:,5) = max(filter_response(:,25:30),[],2);
-    filter_response_MR8(:,6) = max(filter_response(:,31:36),[],2);
+    
+    % pick the *absolute* maximum response
+    filter_response_MR8(:,1) = max(abs(filter_response(:,1:6)),[],2);
+    filter_response_MR8(:,2) = max(abs(filter_response(:,7:12)),[],2);
+    filter_response_MR8(:,3) = max(abs(filter_response(:,13:18)),[],2);
+    filter_response_MR8(:,4) = max(abs(filter_response(:,19:24)),[],2);
+    filter_response_MR8(:,5) = max(abs(filter_response(:,25:30)),[],2);
+    filter_response_MR8(:,6) = max(abs(filter_response(:,31:36)),[],2);
+    
     filter_response_MR8(:,7:8) = filter_response(:,37:38);
     filter_response = filter_response_MR8;
 end


### PR DESCRIPTION
I found that the part of maximum response code has small issue.
If the filter bank covers 2pi (i.e. [-pi:pi) ), the original code will work properly.
However, the filter bank in this implementation (from original VGG) only covers pi (i.e. [-pi:pi) ) due to symmetry. Therefore, it is needed to pick the absolute maximum response.

Although it is a small issue, but I think it will affect the result in some cases. Please check my commit a8b578b . Thank you.